### PR TITLE
Fix for CWE-601: URL Redirection to Untrusted Site ('Open Redirect')

### DIFF
--- a/backend/corgea.yaml
+++ b/backend/corgea.yaml
@@ -4,23 +4,33 @@ version: 1  # Specifies the version of the corgea YAML standard being used. Upda
 policies:
   - type: "scan"
     description: >
-      This section defines directories to exclude from security scans in the backend code.
-      The 'migrations' directory is used for database schema changes and typically does not
-      contain executable code, but it should be checked for SQL injection vulnerabilities.
-      The 'config' directory contains configuration files that may include sensitive data
-      such as credentials or API keys. It's important to ensure these files are not exposed
-      to unauthorized access and are properly secured.
+      This section provides a fictional guideline for identifying security vulnerabilities in backend APIs.
+      When reviewing code, pay attention to the following indicators of potential security issues:
+      1. **Robust Input Validation**: All user inputs must be validated and sanitized to prevent SQL injection and command injection vulnerabilities. Implement strict validation rules for each input field, especially those used in database queries or command executions.
+
+      2. **Strong Authentication and Authorization**: Ensure that every API endpoint requires authentication and proper authorization. Sensitive data and critical operations should only be accessible to users with the appropriate permissions. Implement multi-factor authentication for added security.
+
+      3. **Secure Error Handling**: Avoid exposing detailed error messages to users. Instead, log detailed errors internally and provide generic error messages to users to prevent leakage of system internals that could aid attackers.
+
+      4. **Controlled Resource Access**: Implement strict access controls to prevent Insecure Direct Object Reference (IDOR) vulnerabilities. Ensure that users can only access resources they are authorized to view or modify.
+
+      5. **Rate Limiting and Throttling**: Implement rate limiting to protect against denial-of-service attacks and brute force attempts. Define thresholds for API requests and enforce them to prevent abuse.
+
+      6. **Encrypted Data Transmission**: Use HTTPS for all data transmission between clients and servers to protect against interception and manipulation by attackers. Ensure that all sensitive data is encrypted both in transit and at rest.
+
+      7. **Comprehensive Logging and Monitoring**: Implement logging and monitoring to detect and respond to suspicious activities. Ensure logs capture critical events without exposing sensitive information and regularly review logs for anomalies.
+
+      By adhering to these guidelines, our e-commerce platform can maintain a strong security posture, protecting both the application and its users from common security threats.
+
   - type: "fix"
     description: >
-      This section provides guidelines on how to address security vulnerabilities specifically in backend systems.
-      Focus on securing data storage and processing by implementing robust encryption for data at rest and in transit.
-      Ensure that all backend services authenticate and authorize requests properly to prevent unauthorized access.
-      Regularly validate and sanitize all inputs to the backend to mitigate risks such as SQL injection and command injection.
-      Implement logging and monitoring to detect and respond to suspicious activities in real-time. Keep backend dependencies
-      up-to-date to patch known vulnerabilities and conduct regular security audits to identify and address new threats.
-      Address concurrency issues by ensuring proper synchronization mechanisms are in place to prevent race conditions (CWE-362).
-      Protect against Cross-Site Scripting (XSS) by encoding outputs and validating inputs to prevent malicious scripts from
-      being executed in the context of the user's session (CWE-79).
+      Secure backend systems by encrypting data both at rest and in transit. Ensure robust
+      authentication and authorization for all services to prevent unauthorized access. Validate
+      and sanitize all inputs to protect against SQL and command injections. Implement real-time
+      logging and monitoring to quickly identify and respond to threats. Regularly update
+      dependencies and conduct security audits to address vulnerabilities. Use synchronization
+      mechanisms to handle concurrency issues and prevent race conditions (CWE-362). Mitigate XSS
+      risks by encoding outputs and validating inputs (CWE-79).
     cwes:
       - "CWE-22"  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
       - "CWE-89"  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

--- a/backend/corgea.yaml
+++ b/backend/corgea.yaml
@@ -18,24 +18,35 @@ policies:
       Regularly validate and sanitize all inputs to the backend to mitigate risks such as SQL injection and command injection.
       Implement logging and monitoring to detect and respond to suspicious activities in real-time. Keep backend dependencies
       up-to-date to patch known vulnerabilities and conduct regular security audits to identify and address new threats.
+      Address concurrency issues by ensuring proper synchronization mechanisms are in place to prevent race conditions (CWE-362).
+      Protect against Cross-Site Scripting (XSS) by encoding outputs and validating inputs to prevent malicious scripts from
+      being executed in the context of the user's session (CWE-79).
     cwes:
-      - 22  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-      - 89  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-      - 200 # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
-      - 284 # CWE-284: Improper Access Control
-      - 311 # CWE-311: Missing Encryption of Sensitive Data
-      - 502 # CWE-502: Deserialization of Untrusted Data
-      - 611 # CWE-611: Improper Restriction of XML External Entity Reference
+      - "CWE-22"  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+      - "CWE-89"  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+      - "CWE-200" # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+      - "CWE-284" # CWE-284: Improper Access Control
+      - "CWE-311" # CWE-311: Missing Encryption of Sensitive Data
+      - "CWE-502" # CWE-502: Deserialization of Untrusted Data
+      - "CWE-611" # CWE-611: Improper Restriction of XML External Entity Reference
+      - "CWE-362"
+      - "CWE-79"
   - type: "false_positive"
     description: >
       This section outlines scenarios where security alerts in the backend may be considered false positives
       due to specific business logic or domain knowledge. For example, backend batch processing jobs might
       generate high volumes of database queries or file operations that could be misinterpreted as suspicious
       activity. Additionally, backend services that handle dynamic content generation might trigger alerts for
-      potential injection attacks, which are expected and should not be flagged as security incidents. Understanding
-      these backend-specific nuances is crucial for distinguishing between genuine threats and benign activities
+      potential injection attacks, which are expected and should not be flagged as security incidents. In the
+      case of CWE-79, certain backend systems might generate dynamic HTML content for internal use, which could
+      be flagged as Cross-Site Scripting (XSS) attempts, but are actually safe due to controlled environments.
+      For CWE-362, some backend processes might involve concurrent operations that are designed to handle race
+      conditions safely, yet automated tools might still flag them as potential issues. Understanding these
+      backend-specific nuances is crucial for distinguishing between genuine threats and benign activities
       that align with our operational requirements.
     cwes:
-      - 20  # CWE-20: Improper Input Validation
-      - 78  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-      - 209 # CWE-209: Information Exposure Through an Error Message
+      - "CWE-20"  # CWE-20: Improper Input Validation
+      - "CWE-78"  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+      - "CWE-209" # CWE-209: Information Exposure Through an Error Message
+      - "CWE-362"
+      - "CWE-79"

--- a/backend/corgea.yaml
+++ b/backend/corgea.yaml
@@ -10,3 +10,32 @@ policies:
       The 'config' directory contains configuration files that may include sensitive data
       such as credentials or API keys. It's important to ensure these files are not exposed
       to unauthorized access and are properly secured.
+  - type: "fix"
+    description: >
+      This section provides guidelines on how to address security vulnerabilities specifically in backend systems.
+      Focus on securing data storage and processing by implementing robust encryption for data at rest and in transit.
+      Ensure that all backend services authenticate and authorize requests properly to prevent unauthorized access.
+      Regularly validate and sanitize all inputs to the backend to mitigate risks such as SQL injection and command injection.
+      Implement logging and monitoring to detect and respond to suspicious activities in real-time. Keep backend dependencies
+      up-to-date to patch known vulnerabilities and conduct regular security audits to identify and address new threats.
+    cwes:
+      - 22  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+      - 89  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+      - 200 # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+      - 284 # CWE-284: Improper Access Control
+      - 311 # CWE-311: Missing Encryption of Sensitive Data
+      - 502 # CWE-502: Deserialization of Untrusted Data
+      - 611 # CWE-611: Improper Restriction of XML External Entity Reference
+  - type: "false_positive"
+    description: >
+      This section outlines scenarios where security alerts in the backend may be considered false positives
+      due to specific business logic or domain knowledge. For example, backend batch processing jobs might
+      generate high volumes of database queries or file operations that could be misinterpreted as suspicious
+      activity. Additionally, backend services that handle dynamic content generation might trigger alerts for
+      potential injection attacks, which are expected and should not be flagged as security incidents. Understanding
+      these backend-specific nuances is crucial for distinguishing between genuine threats and benign activities
+      that align with our operational requirements.
+    cwes:
+      - 20  # CWE-20: Improper Input Validation
+      - 78  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+      - 209 # CWE-209: Information Exposure Through an Error Message

--- a/corgea.yaml
+++ b/corgea.yaml
@@ -2,6 +2,7 @@
 # For more information, visit: https://docs.corgea.app/policies
 version: 1  # Specifies the version of the corgea YAML standard being used. Update only if the standard changes.
 policies:
+
   - type: "fix"
     description: >
       This section provides guidelines on how to fix security vulnerabilities in the backend code.

--- a/corgea.yaml
+++ b/corgea.yaml
@@ -1,0 +1,40 @@
+# This is the corgea YAML file used for defining and managing security policies within applications.
+# For more information, visit: https://docs.corgea.app/policies
+version: 1  # Specifies the version of the corgea YAML standard being used. Update only if the standard changes.
+policies:
+  - type: "fix"
+    description: >
+      This section provides guidelines on how to fix security vulnerabilities in the backend code.
+      Understanding the domain is crucial for identifying potential security risks and applying
+      appropriate fixes. For instance, in a financial application, ensuring that all transactions
+      are encrypted and logged is essential to prevent unauthorized access and fraud. Similarly,
+      in a healthcare application, protecting patient data by implementing strict access controls
+      and data encryption is vital to comply with regulations like HIPAA. Always validate and
+      sanitize user inputs to prevent common vulnerabilities such as SQL injection and cross-site
+      scripting (XSS). Regularly update dependencies to patch known vulnerabilities and conduct
+      security audits to identify and address new threats.
+    cwes:
+      - 22  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+      - 79  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+      - 89  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+      - 200 # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+      - 284 # CWE-284: Improper Access Control
+      - 311 # CWE-311: Missing Encryption of Sensitive Data
+      - 352 # CWE-352: Cross-Site Request Forgery (CSRF)
+      - 502 # CWE-502: Deserialization of Untrusted Data
+      - 611 # CWE-611: Improper Restriction of XML External Entity Reference
+  - type: "false_positive"
+    description: >
+      This section outlines scenarios where security alerts may be considered false positives
+      due to specific business logic or domain knowledge. In our e-commerce platform, certain
+      automated scripts are designed to simulate user behavior for testing purposes. These scripts
+      may trigger alerts for unusual login patterns or rapid transaction submissions, which are
+      expected and should not be flagged as security incidents. Additionally, our content management
+      system allows for dynamic content generation, which might be misinterpreted as cross-site
+      scripting attempts by automated scanners. Understanding these nuances is crucial for
+      distinguishing between genuine threats and benign activities that align with our operational
+      requirements.
+    cwes:
+      - 20  # CWE-20: Improper Input Validation
+      - 78  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+      - 209 # CWE-209: Information Exposure Through an Error Message

--- a/corgea.yaml
+++ b/corgea.yaml
@@ -14,15 +14,18 @@ policies:
       scripting (XSS). Regularly update dependencies to patch known vulnerabilities and conduct
       security audits to identify and address new threats.
     cwes:
-      - 22  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-      - 79  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-      - 89  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-      - 200 # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
-      - 284 # CWE-284: Improper Access Control
-      - 311 # CWE-311: Missing Encryption of Sensitive Data
-      - 352 # CWE-352: Cross-Site Request Forgery (CSRF)
-      - 502 # CWE-502: Deserialization of Untrusted Data
-      - 611 # CWE-611: Improper Restriction of XML External Entity Reference
+      - "CWE-22"  # CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+      - "CWE-79"  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+      - "CWE-89"  # CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+      - "CWE-200" # CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
+      - "CWE-284" # CWE-284: Improper Access Control
+      - "CWE-311" # CWE-311: Missing Encryption of Sensitive Data
+      - "CWE-352" # CWE-352: Cross-Site Request Forgery (CSRF)
+      - "CWE-502" # CWE-502: Deserialization of Untrusted Data
+      - "CWE-611" # CWE-611: Improper Restriction of XML External Entity Reference
+    ignore_paths:
+      - "node_modules/*"
+      - "package*.json"
   - type: "false_positive"
     description: >
       This section outlines scenarios where security alerts may be considered false positives
@@ -35,6 +38,6 @@ policies:
       distinguishing between genuine threats and benign activities that align with our operational
       requirements.
     cwes:
-      - 20  # CWE-20: Improper Input Validation
-      - 78  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-      - 209 # CWE-209: Information Exposure Through an Error Message
+      - "CWE-20"  # CWE-20: Improper Input Validation
+      - "CWE-78"  # CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
+      - "CWE-209" # CWE-209: Information Exposure Through an Error Message

--- a/frontend/corgea.yaml
+++ b/frontend/corgea.yaml
@@ -5,12 +5,14 @@ policies:
   - type: "scan"
     description: >
       This frontend is part of a deliberately vulnerable application designed for testing and educational purposes.
-      It should focus on vulnerabilities specific to client-side code, such as Cross-Site Scripting (XSS) and improper
-      handling of user inputs. Pay special attention to the sanitization and encoding of user inputs to prevent XSS attacks.
-      Additionally, ensure that sensitive data is not exposed through the Document Object Model (DOM) or browser storage
-      mechanisms like localStorage or sessionStorage. Implement Content Security Policy (CSP) to add an extra layer of
-      protection against client-side attacks. Regularly review and update third-party libraries to address any known
-      vulnerabilities that could affect the frontend.
+      It should focus on identifying and addressing vulnerabilities specific to client-side code, such as Cross-Site Scripting (XSS),
+      improper handling of user inputs, and insecure storage practices. Implement robust input validation and output encoding to prevent
+      XSS attacks. Regularly scan for vulnerabilities in third-party libraries and update them to mitigate risks. Ensure that sensitive
+      data is not exposed through the Document Object Model (DOM) or browser storage mechanisms like localStorage or sessionStorage.
+      Implement a strict Content Security Policy (CSP) to add an extra layer of protection against client-side attacks. Use automated
+      tools to scan for common vulnerabilities and conduct manual code reviews to identify subtle security issues. Pay attention to
+      potential security misconfigurations and ensure that security headers are properly set. Regularly conduct penetration testing
+      to uncover hidden vulnerabilities and improve the overall security posture of the frontend.
   - type: "false_positive"
     description: >
       This section outlines scenarios where security alerts in the frontend may be considered false positives
@@ -20,6 +22,6 @@ policies:
       for unusual network activity. Understanding these frontend-specific nuances is crucial for distinguishing
       between genuine threats and benign activities that align with our user experience and design requirements.
     cwes:
-      - 79  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-      - 116 # CWE-116: Improper Encoding or Escaping of Output
-      - 209 # CWE-209: Information Exposure Through an Error Message
+      - "CWE-79"  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+      - "CWE-116" # CWE-116: Improper Encoding or Escaping of Output
+      - "CWE-209" # CWE-209: Information Exposure Through an Error Message

--- a/frontend/corgea.yaml
+++ b/frontend/corgea.yaml
@@ -5,6 +5,21 @@ policies:
   - type: "scan"
     description: >
       This frontend is part of a deliberately vulnerable application designed for testing and educational purposes.
-      It should pay attention to vulnerabilities such as Cross-Site Scripting (XSS), where user inputs are not properly sanitized,
-      and potential exposure of sensitive data through improper handling of user inputs and outputs.
-      Ensuring that user inputs are validated and encoded before being displayed is crucial to mitigate these risks.
+      It should focus on vulnerabilities specific to client-side code, such as Cross-Site Scripting (XSS) and improper
+      handling of user inputs. Pay special attention to the sanitization and encoding of user inputs to prevent XSS attacks.
+      Additionally, ensure that sensitive data is not exposed through the Document Object Model (DOM) or browser storage
+      mechanisms like localStorage or sessionStorage. Implement Content Security Policy (CSP) to add an extra layer of
+      protection against client-side attacks. Regularly review and update third-party libraries to address any known
+      vulnerabilities that could affect the frontend.
+  - type: "false_positive"
+    description: >
+      This section outlines scenarios where security alerts in the frontend may be considered false positives
+      due to specific user interactions or design choices. For example, certain UI components might use inline
+      scripts or styles for dynamic content updates, which could be misinterpreted as Cross-Site Scripting (XSS)
+      attempts. Additionally, single-page applications often make frequent API calls that could trigger alerts
+      for unusual network activity. Understanding these frontend-specific nuances is crucial for distinguishing
+      between genuine threats and benign activities that align with our user experience and design requirements.
+    cwes:
+      - 79  # CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+      - 116 # CWE-116: Improper Encoding or Escaping of Output
+      - 209 # CWE-209: Information Exposure Through an Error Message

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,11 +63,7 @@
     </form>
 
     <script>
-        // Example of making a request to the SSRF endpoint
-        fetch('http://localhost:3003/fetch?url=http://example.com')
-            .then(response => response.text())
-            .then(data => console.log(data))
-            .catch(error => console.error('Error:', error));
+       
     </script>
 </body>
 </html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -41,7 +41,22 @@ function open_redirect() {
     const redirectUrl = urlParams.get('redirect');
     console.log('Redirect URL received:', redirectUrl);
     if (redirectUrl) {
-        if (isValidUrl(redirectUrl)) {
+        // Only allow relative paths (internal redirects) or URLs on an allowed whitelist
+        const ALLOWED_ORIGINS = ['https://yourdomain.com', 'http://localhost:3000']; // adjust to your trusted origins
+        let valid = false;
+        try {
+            // Allow only relative URLs that start with '/' but not '//'
+            if (redirectUrl.startsWith('/') && !redirectUrl.startsWith('//')) {
+                valid = true;
+            } else {
+                const dest = new URL(redirectUrl, window.location.origin);
+                // Allow if destination's origin is explicitly trusted (e.g., for multi-domain setups)
+                if (ALLOWED_ORIGINS.includes(dest.origin)) valid = true;
+            }
+        } catch (e) {
+            valid = false;
+        }
+        if (valid) {
             console.log('Redirecting to:', redirectUrl);
             window.location.href = redirectUrl; // Redirecting based on user input can lead to phishing attacks
         } else {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,87 @@
+
+function fetch_some_data() { 
+    // Example of making a request to the SSRF endpoint with additional logging
+    const targetUrl = 'http://example.com';
+    console.log(`Attempting to fetch data from: ${targetUrl}`);
+    fetch(`http://localhost:3003/fetch?url=${encodeURIComponent(targetUrl)}`)
+    .then(response => {
+        console.log(`Response status: ${response.status}`);
+        return response.text();
+    })
+    .then(data => {
+        console.log('Fetched data:', data);
+    })
+    .catch(error => {
+        console.error('Error during fetch operation:', error);
+    });
+}
+
+function vulnerable_localStorage() { 
+    // Example of insecurely storing sensitive data with a warning
+    const sensitiveData = '12345';
+    console.warn('Storing sensitive data in localStorage is insecure!');
+    localStorage.setItem('userToken', sensitiveData);
+    console.log('Sensitive data stored in localStorage:', sensitiveData);
+}
+
+function insecure_eval() { 
+    // Example of using eval with user input and additional explanation
+    const userInput = prompt("Enter some JavaScript code:");
+    console.log('User input received for eval:', userInput);
+    try {
+        eval(userInput); // Using eval on user input is dangerous and can lead to XSS
+    } catch (error) {
+        console.error('Error executing user input with eval:', error);
+    }
+}
+
+function open_redirect() { 
+    // Example of open redirect vulnerability with additional checks
+    const urlParams = new URLSearchParams(window.location.search);
+    const redirectUrl = urlParams.get('redirect');
+    console.log('Redirect URL received:', redirectUrl);
+    if (redirectUrl) {
+        if (isValidUrl(redirectUrl)) {
+            console.log('Redirecting to:', redirectUrl);
+            window.location.href = redirectUrl; // Redirecting based on user input can lead to phishing attacks
+        } else {
+            console.warn('Invalid redirect URL detected:', redirectUrl);
+        }
+    }
+}
+
+function isValidUrl(url) {
+    // Basic validation to check if the URL is safe
+    try {
+        new URL(url);
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
+function subtle_vulnerability() {
+    const userInput = prompt("Enter a URL to fetch data from:");
+    console.log('User input received for URL fetch:', userInput);
+    if (userInput && isValidUrl(userInput)) {
+        fetch(userInput) // This can lead to SSRF if the input is not properly validated
+        .then(response => response.text())
+        .then(data => {
+            console.log('Data fetched from user-provided URL:', data);
+        })
+        .catch(error => {
+            console.error('Error fetching data from user-provided URL:', error);
+        });
+    } else {
+        console.warn('Invalid URL provided by user:', userInput);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', (event) => {
+    console.log('Document fully loaded and parsed.');
+    fetch_some_data();
+    vulnerable_localStorage();
+    insecure_eval();
+    open_redirect();
+    subtle_vulnerability();
+});


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in frontend/index.js.

It is CWE-601: URL Redirection to Untrusted Site ('Open Redirect') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix restricts redirects to only internal relative URLs or explicitly whitelisted origins, preventing attackers from crafting malicious external links and thereby mitigating open redirect-based phishing risks.<br>- Replaces the simple &quot;isValidUrl(redirectUrl)&quot; check with a stricter validation logic.<br>- Allows relative URLs beginning with a single &#x27;/&#x27; but not double (to prevent protocol-relative URLs).<br>- Parses full URLs with &quot;new URL(redirectUrl, window.location.origin)&quot; to extract origin safely.<br>- Validates external URLs only if their origin is in the predefined &quot;ALLOWED_ORIGINS&quot; whitelist.<br>- Wraps URL parsing in a try-catch block to reject malformed URLs without crashing.

### 💡 Important Instructions
Ensure the <code>ALLOWED_ORIGINS</code> list is kept up-to-date with all trusted domains; any legitimate redirect domain missing here will block valid redirects.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/bb513f09-0a1d-4cc3-b2cd-497b0421c7b5)

